### PR TITLE
feat: #WB-1956, add an extension managing typography sizes

### DIFF
--- a/packages/extension-typosize/.gitignore
+++ b/packages/extension-typosize/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/packages/extension-typosize/.npmrc
+++ b/packages/extension-typosize/.npmrc
@@ -1,0 +1,1 @@
+auto-install-peers=true

--- a/packages/extension-typosize/README.md
+++ b/packages/extension-typosize/README.md
@@ -1,0 +1,26 @@
+# extension-typosize
+
+![npm](https://img.shields.io/npm/v/@edifice-tiptap-extensions/extension-typosize?style=flat-square)
+![bundlephobia](https://img.shields.io/bundlephobia/min/@edifice-tiptap-extensions/extension-typosize?style=flat-square)
+
+A Tiptap extension that extends Heading.
+
+## Installation
+
+With `npm`:
+
+```bash
+npm install @edifice-tiptap-extensions/extension-typosize
+```
+
+With `yarn`:
+
+```bash
+yarn add @edifice-tiptap-extensions/extension-typosize
+```
+
+With `pnpm`:
+
+```bash
+pnpm add @edifice-tiptap-extensions/extension-typosize
+```

--- a/packages/extension-typosize/package.json
+++ b/packages/extension-typosize/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@edifice-tiptap-extensions/extension-typosize",
+  "version": "1.0.0",
+  "description": "Rich Text Editor TypoSize Extension",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist/*"
+  ],
+  "scripts": {
+    "build": "pnpm run clean && rollup -c",
+    "clean": "rm -rf dist",
+    "dev": "pnpm run clean && rollup -c -w",
+    "format": "pnpm run format:write && pnpm run format:check",
+    "format:check": "prettier --check 'src/**/*.ts'",
+    "format:write": "prettier --write 'src/**/*.ts'",
+    "lint": "eslint src --ext ts --report-unused-disable-directives --max-warnings 0",
+    "fix": "eslint src --fix --ext ts --report-unused-disable-directives --max-warnings 0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-babel": "^6.0.3",
+    "@rollup/plugin-commonjs": "^24.0.1",
+    "@tiptap/extension-heading": "2.0.3",
+    "@tiptap/core": "2.0.3",
+    "@tiptap/pm": "2.0.3",
+    "rollup": "^3.17.3",
+    "rollup-plugin-auto-external": "^2.0.0",
+    "rollup-plugin-sourcemaps": "^0.6.3",
+    "rollup-plugin-typescript2": "^0.34.1"
+  },
+  "peerDependencies": {
+    "@tiptap/core": "2.0.3",
+    "@tiptap/pm": "2.0.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/extension-typosize/rollup.config.js
+++ b/packages/extension-typosize/rollup.config.js
@@ -1,0 +1,34 @@
+// rollup.config.js
+
+import autoExternal from 'rollup-plugin-auto-external';
+import sourcemaps from 'rollup-plugin-sourcemaps';
+import commonjs from '@rollup/plugin-commonjs';
+import babel from '@rollup/plugin-babel';
+import typescript from 'rollup-plugin-typescript2';
+
+const config = {
+  input: 'src/index.ts',
+  output: [
+    {
+      file: 'dist/index.cjs',
+      format: 'cjs',
+      exports: 'named',
+      sourcemap: true,
+    },
+    {
+      file: 'dist/index.js',
+      format: 'esm',
+      exports: 'named',
+      sourcemap: true,
+    },
+  ],
+  plugins: [
+    autoExternal({ packagePath: './package.json' }),
+    sourcemaps(),
+    babel(),
+    commonjs(),
+    typescript(),
+  ],
+};
+
+export default config;

--- a/packages/extension-typosize/src/TypoSize.ts
+++ b/packages/extension-typosize/src/TypoSize.ts
@@ -1,0 +1,109 @@
+import { mergeAttributes } from '@tiptap/core';
+import Heading from '@tiptap/extension-heading';
+
+export declare type TypoSizeLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    typoSize: {
+      /**
+       * Change text size (normal size is level 5)
+       */
+      setTypoSize: (attributes: { level: TypoSizeLevel }) => ReturnType;
+      /**
+       * Toggle text size
+       */
+      toggleTypoSize: (attributes: { level: TypoSizeLevel }) => ReturnType;
+      /**
+       * Reset text size to normal
+       */
+      unsetTypoSize: () => ReturnType;
+    };
+  }
+}
+
+const TypoSize = Heading.extend({
+  name: 'typoSize',
+
+  parseHTML() {
+    return this.options.levels.map((level: TypoSizeLevel) => {
+      switch (level) {
+        // Level 6 is small text, modeled as a <small> tag
+        case 6:
+          return {
+            tag: `small`,
+            attrs: { level },
+          };
+        // Level 5 is normal text, modeled as a <p> tag
+        case 5:
+          return {
+            tag: `p`,
+            attrs: { level },
+          };
+        // Other levels are <hX> tags
+        default:
+          return {
+            tag: `h${level}`,
+            attrs: { level },
+          };
+      }
+    });
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    const level = this.options.levels.includes(node.attrs.level)
+      ? node.attrs.level
+      : this.options.levels[0];
+    switch (level) {
+      case 6:
+        return [
+          `small`,
+          mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
+          0,
+        ];
+      case 5:
+        return [
+          `p`,
+          mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
+          0,
+        ];
+      default:
+        return [
+          `h${level}`,
+          mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
+          0,
+        ];
+    }
+  },
+
+  addCommands() {
+    return {
+      setTypoSize:
+        (attributes) =>
+        ({ commands }) => {
+          if (!this.options.levels.includes(attributes.level)) {
+            return false;
+          }
+
+          return commands.setNode(this.name, attributes);
+        },
+      toggleTypoSize:
+        (attributes) =>
+        ({ commands }) => {
+          if (!this.options.levels.includes(attributes.level)) {
+            return false;
+          }
+
+          return commands.toggleNode(this.name, 'paragraph', attributes);
+        },
+      unsetTypoSize:
+        () =>
+        ({ commands }) => {
+          return commands.toggleNode(this.name, 'paragraph', { level: 5 });
+        },
+    };
+  },
+});
+
+export { TypoSize };
+export default TypoSize;

--- a/packages/extension-typosize/src/index.ts
+++ b/packages/extension-typosize/src/index.ts
@@ -1,3 +1,3 @@
-import TypoSize from './TypoSize';
+import TypoSize, { TypoSizeLevel } from './TypoSize';
 
-export { TypoSize };
+export { TypoSize, TypoSizeLevel };

--- a/packages/extension-typosize/src/index.ts
+++ b/packages/extension-typosize/src/index.ts
@@ -1,0 +1,3 @@
+import TypoSize from './TypoSize';
+
+export { TypoSize };

--- a/packages/extension-typosize/tsconfig.json
+++ b/packages/extension-typosize/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "ES2015",
+    "lib": ["es2015", "dom"],
+    "moduleResolution": "node",
+    "declaration": true,
+    "noEmit": true,
+    "rootDir": "./src"
+  },
+  "exclude": ["dist", "build", "node_modules"]
+}


### PR DESCRIPTION
Cette extension permet de gérer la taille de la typo.
Elle étend l'extension Heading de Tiptap.

Les niveaux 1 à 4 sont considérés comme des titres HTML (tags h1, h2, h3 et h4)
Le niveau 5 est la taille "normale", considérés comme un paragraphe HTML (tag p)
Le niveau 6 est la petite taille, considérés comme un &lt;small&gt; HTML