### PR TITLE
[Edifice] Ajout extension de rattrapage des anciennes formules MathJax

### DIFF
--- a/packages/extension-mathjax/.gitignore
+++ b/packages/extension-mathjax/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/packages/extension-mathjax/.npmrc
+++ b/packages/extension-mathjax/.npmrc
@@ -1,0 +1,1 @@
+auto-install-peers=true

--- a/packages/extension-mathjax/README.md
+++ b/packages/extension-mathjax/README.md
@@ -1,0 +1,26 @@
+# extension-video
+
+![npm](https://img.shields.io/npm/v/@edifice-tiptap-extensions/extension-video?style=flat-square)
+![bundlephobia](https://img.shields.io/bundlephobia/min/@edifice-tiptap-extensions/extension-video?style=flat-square)
+
+A Tiptap extension that handles the conversion of old MathJax formulae to TipTap Mathematics extension.
+
+## Installation
+
+With `npm`:
+
+```bash
+npm install @edifice-tiptap-extensions/extension-mathjax
+```
+
+With `yarn`:
+
+```bash
+yarn add @edifice-tiptap-extensions/extension-mathjax
+```
+
+With `pnpm`:
+
+```bash
+pnpm add @edifice-tiptap-extensions/extension-mathjax
+```

--- a/packages/extension-mathjax/package.json
+++ b/packages/extension-mathjax/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@edifice-tiptap-extensions/extension-mathjax",
+  "version": "1.0.0",
+  "description": "Rich Text Editor MathJax Extension",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist/*"
+  ],
+  "scripts": {
+    "build": "pnpm run clean && rollup -c",
+    "clean": "rm -rf dist",
+    "dev": "pnpm run clean && rollup -c -w",
+    "format": "pnpm run format:write && pnpm run format:check",
+    "format:check": "prettier --check 'src/**/*.ts'",
+    "format:write": "prettier --write 'src/**/*.ts'",
+    "lint": "eslint src --ext ts --report-unused-disable-directives --max-warnings 0",
+    "fix": "eslint src --fix --ext ts --report-unused-disable-directives --max-warnings 0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-babel": "^6.0.3",
+    "@rollup/plugin-commonjs": "^24.0.1",
+    "@tiptap/core": "2.0.3",
+    "@tiptap/pm": "2.0.3",
+    "rollup": "^3.17.3",
+    "rollup-plugin-auto-external": "^2.0.0",
+    "rollup-plugin-sourcemaps": "^0.6.3",
+    "rollup-plugin-typescript2": "^0.34.1"
+  },
+  "peerDependencies": {
+    "@tiptap/core": "2.0.3",
+    "@tiptap/pm": "2.0.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/extension-mathjax/rollup.config.js
+++ b/packages/extension-mathjax/rollup.config.js
@@ -1,0 +1,34 @@
+// rollup.config.js
+
+import autoExternal from 'rollup-plugin-auto-external';
+import sourcemaps from 'rollup-plugin-sourcemaps';
+import commonjs from '@rollup/plugin-commonjs';
+import babel from '@rollup/plugin-babel';
+import typescript from 'rollup-plugin-typescript2';
+
+const config = {
+  input: 'src/index.ts',
+  output: [
+    {
+      file: 'dist/index.cjs',
+      format: 'cjs',
+      exports: 'named',
+      sourcemap: true,
+    },
+    {
+      file: 'dist/index.js',
+      format: 'esm',
+      exports: 'named',
+      sourcemap: true,
+    },
+  ],
+  plugins: [
+    autoExternal({ packagePath: './package.json' }),
+    sourcemaps(),
+    babel(),
+    commonjs(),
+    typescript(),
+  ],
+};
+
+export default config;

--- a/packages/extension-mathjax/src/index.ts
+++ b/packages/extension-mathjax/src/index.ts
@@ -1,0 +1,3 @@
+import MathJax from './mathjax';
+
+export { MathJax };

--- a/packages/extension-mathjax/src/mathjax.ts
+++ b/packages/extension-mathjax/src/mathjax.ts
@@ -1,0 +1,48 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Node } from '@tiptap/core';
+
+
+const MathJaxNode = Node.create({
+  name: 'mathjaxnode',
+  group: 'inline',
+  inline: true,
+  atom: false,
+  selectable: true,
+
+
+  parseHTML() {
+    return [
+      {
+        tag: 'mathjax',
+      },
+    ];
+  },
+
+  addAttributes() {
+    return {
+      equation: {
+        default: null,
+        parseHTML: (element: any) => {
+          const equationNode = [...element.childNodes]
+            .filter(child => child.nodeType === 3)
+            .filter(child => child.data.indexOf('begin{equation') >= 0)[0]
+          if (equationNode) {
+            return equationNode.nodeValue
+          } else {
+            return null;
+          }
+        }
+      }
+    }
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const equation = (HTMLAttributes.equation || '')
+      .replaceAll(/\\begin{equation}\s*\n?\s*{/mg, '$')
+      .replaceAll(/}\n?\s*\\end{equation}/mg, '$');
+    return ['span', {}, equation];
+  },
+})
+
+export { MathJaxNode };
+export default MathJaxNode;

--- a/packages/extension-mathjax/tsconfig.json
+++ b/packages/extension-mathjax/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "ES2015",
+    "lib": ["es2015", "dom"],
+    "moduleResolution": "node",
+    "declaration": true,
+    "noEmit": true,
+    "rootDir": "./src"
+  },
+  "exclude": ["dist", "build", "node_modules"]
+}


### PR DESCRIPTION
# Description

Cette extension a pour but de transformer les anciennes formules provenant de la librairie MathJax vers le format compris par TipTap.

La conversion est faite en s'appuyant sur la valeur du dernier nœud de la balise `<mathjax>` qui contient l'expression mathématique comprise par TipTap (modulo les marqueurs de début et de fin d'équation).

# Ticket

WB-2164