### PR TITLE
[Edifice] Correction MathJax pour node

### DIFF
--- a/packages/extension-mathjax/src/mathjax.ts
+++ b/packages/extension-mathjax/src/mathjax.ts
@@ -25,7 +25,7 @@ const MathJaxNode = Node.create({
         parseHTML: (element: any) => {
           const equationNode = [...element.childNodes]
             .filter(child => child.nodeType === 3)
-            .filter(child => child.data.indexOf('begin{equation') >= 0)[0]
+            .filter(child => child.nodeValue.indexOf('begin{equation') >= 0)[0]
           if (equationNode) {
             return equationNode.nodeValue
           } else {


### PR DESCRIPTION
# Description

L'extension MathJax plante lorsqu'elle est exécutée en dehors du navigateur car le champ `data` n'existe pas. Il a été remplacé par un appel au champ `nodeValue` qui existe dans tous les contextes