### PR TITLE
 [EDIFICE] Reprise des "modèles" de l'ancien éditeur

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+.idea

--- a/packages/extension-templates/.gitignore
+++ b/packages/extension-templates/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/packages/extension-templates/.npmrc
+++ b/packages/extension-templates/.npmrc
@@ -1,0 +1,1 @@
+auto-install-peers=true

--- a/packages/extension-templates/README.md
+++ b/packages/extension-templates/README.md
@@ -1,0 +1,26 @@
+# extension-templates
+
+![npm](https://img.shields.io/npm/v/@edifice-tiptap-extensions/extension-templates?style=flat-square)
+![bundlephobia](https://img.shields.io/bundlephobia/min/@edifice-tiptap-extensions/extension-templates?style=flat-square)
+
+A Tiptap extension that handles the conversion of old templates (2 and 3 columns) to tables.
+
+## Installation
+
+With `npm`:
+
+```bash
+npm install @edifice-tiptap-extensions/extension-templates
+```
+
+With `yarn`:
+
+```bash
+yarn add @edifice-tiptap-extensions/extension-templates
+```
+
+With `pnpm`:
+
+```bash
+pnpm add @edifice-tiptap-extensions/extension-templates
+```

--- a/packages/extension-templates/package.json
+++ b/packages/extension-templates/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@edifice-tiptap-extensions/extension-templates",
+  "version": "1.0.0",
+  "description": "Rich Text Editor MathJax Extension",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist/*"
+  ],
+  "scripts": {
+    "build": "pnpm run clean && rollup -c",
+    "clean": "rm -rf dist",
+    "dev": "pnpm run clean && rollup -c -w",
+    "format": "pnpm run format:write && pnpm run format:check",
+    "format:check": "prettier --check 'src/**/*.ts'",
+    "format:write": "prettier --write 'src/**/*.ts'",
+    "lint": "eslint src --ext ts --report-unused-disable-directives --max-warnings 0",
+    "fix": "eslint src --fix --ext ts --report-unused-disable-directives --max-warnings 0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-babel": "^6.0.3",
+    "@rollup/plugin-commonjs": "^24.0.1",
+    "@tiptap/core": "2.0.3",
+    "@tiptap/pm": "2.0.3",
+    "rollup": "^3.17.3",
+    "rollup-plugin-auto-external": "^2.0.0",
+    "rollup-plugin-sourcemaps": "^0.6.3",
+    "rollup-plugin-typescript2": "^0.34.1"
+  },
+  "peerDependencies": {
+    "@tiptap/core": "2.0.3",
+    "@tiptap/pm": "2.0.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/extension-templates/rollup.config.js
+++ b/packages/extension-templates/rollup.config.js
@@ -1,0 +1,34 @@
+// rollup.config.js
+
+import autoExternal from 'rollup-plugin-auto-external';
+import sourcemaps from 'rollup-plugin-sourcemaps';
+import commonjs from '@rollup/plugin-commonjs';
+import babel from '@rollup/plugin-babel';
+import typescript from 'rollup-plugin-typescript2';
+
+const config = {
+  input: 'src/index.ts',
+  output: [
+    {
+      file: 'dist/index.cjs',
+      format: 'cjs',
+      exports: 'named',
+      sourcemap: true,
+    },
+    {
+      file: 'dist/index.js',
+      format: 'esm',
+      exports: 'named',
+      sourcemap: true,
+    },
+  ],
+  plugins: [
+    autoExternal({ packagePath: './package.json' }),
+    sourcemaps(),
+    babel(),
+    commonjs(),
+    typescript(),
+  ],
+};
+
+export default config;

--- a/packages/extension-templates/src/index.ts
+++ b/packages/extension-templates/src/index.ts
@@ -1,0 +1,3 @@
+import Templates from './templates';
+
+export { Templates };

--- a/packages/extension-templates/src/templates.ts
+++ b/packages/extension-templates/src/templates.ts
@@ -11,7 +11,7 @@ const TemplatesNode = Node.create({
   parseHTML() {
     return [
       {
-        tag: 'div[class=row]'
+        tag: 'div[class=row]',
       },
     ];
   },
@@ -21,37 +21,40 @@ const TemplatesNode = Node.create({
       columns: {
         default: [],
         parseHTML: (element) => {
-          return Array.from(element.getElementsByTagName("article")).map((article: any) => {
-            const title = article.getElementsByTagName("h2")[0];
-            const text = article.getElementsByTagName("p")[0];
-            const img = article.getElementsByTagName("img")[0];
-            return {
-              title: title ? title.textContent : "",
-              content: text ? text.textContent : "",
-              image: img ? img.src : ""
-            };
-          });
-        }
-      }
+          return Array.from(element.getElementsByTagName('article')).map(
+            (article: any) => {
+              const title = article.getElementsByTagName('h2')[0];
+              const text = article.getElementsByTagName('p')[0];
+              const img = article.getElementsByTagName('img')[0];
+              return {
+                title: title ? title.textContent : '',
+                content: text ? text.textContent : '',
+                image: img ? img.src : '',
+              };
+            },
+          );
+        },
+      },
     };
   },
 
   renderHTML({ HTMLAttributes }) {
     const columns = HTMLAttributes.columns || [];
     const titles = columns.map((column) => {
-      return ["th", {}, column.title]
+      return ['th', {}, column.title];
     });
     const cells = columns.map((column) => {
-      if(column.image) {
-        return ["td", {}, ["img", { src: column.image }]]
+      if (column.image) {
+        return ['td', {}, ['img', { src: column.image }]];
       } else {
-        return ["td", {}, column.content]
+        return ['td', {}, column.content];
       }
     });
     return [
-      "table", {},
-      ["thead", {}, ["tr", {}, ...titles ]],
-      ["tbody", {}, ["tr", {}, ...cells ]]
+      'table',
+      {},
+      ['thead', {}, ['tr', {}, ...titles]],
+      ['tbody', {}, ['tr', {}, ...cells]],
     ];
   },
 });

--- a/packages/extension-templates/src/templates.ts
+++ b/packages/extension-templates/src/templates.ts
@@ -1,0 +1,60 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Node } from '@tiptap/core';
+
+const TemplatesNode = Node.create({
+  name: 'templatesnode',
+  group: 'inline',
+  inline: true,
+  atom: false,
+  selectable: true,
+
+  parseHTML() {
+    return [
+      {
+        tag: 'div[class=row]'
+      },
+    ];
+  },
+
+  addAttributes() {
+    return {
+      columns: {
+        default: [],
+        parseHTML: (element) => {
+          return Array.from(element.getElementsByTagName("article")).map((article: any) => {
+            const title = article.getElementsByTagName("h2")[0];
+            const text = article.getElementsByTagName("p")[0];
+            const img = article.getElementsByTagName("img")[0];
+            return {
+              title: title ? title.textContent : "",
+              content: text ? text.textContent : "",
+              image: img ? img.src : ""
+            };
+          });
+        }
+      }
+    };
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const columns = HTMLAttributes.columns || [];
+    const titles = columns.map((column) => {
+      return ["th", {}, column.title]
+    });
+    const cells = columns.map((column) => {
+      if(column.image) {
+        return ["td", {}, ["img", { src: column.image }]]
+      } else {
+        return ["td", {}, column.content]
+      }
+    });
+    return [
+      "table", {},
+      ["thead", {}, ["tr", {}, ...titles ]],
+      ["tbody", {}, ["tr", {}, ...cells ]]
+    ];
+  },
+});
+
+export { TemplatesNode };
+export default TemplatesNode;

--- a/packages/extension-templates/src/templates.ts
+++ b/packages/extension-templates/src/templates.ts
@@ -41,20 +41,19 @@ const TemplatesNode = Node.create({
   renderHTML({ HTMLAttributes }) {
     const columns = HTMLAttributes.columns || [];
     const titles = columns.map((column) => {
-      return ['th', {}, column.title];
-    });
-    const cells = columns.map((column) => {
-      if (column.image) {
-        return ['td', {}, ['img', { src: column.image }]];
+      if(column.title) {
+        return ["td", {'class': 'title'}, ["h2", {}, column.title]];
       } else {
-        return ['td', {}, column.content];
+        return ["td", {'class': 'image', rowspan: 2}, ["img", { src: column.image }]];
       }
     });
+    const cells = columns.filter(c => !!c.content).map(column => {
+      return ["td", {'class': 'text'}, column.content];
+    });
     return [
-      'table',
-      {},
-      ['thead', {}, ['tr', {}, ...titles]],
-      ['tbody', {}, ['tr', {}, ...cells]],
+      "table",
+      {'class': 'template'},
+      ["tbody", {}, ["tr", {}, ...titles], ["tr", {}, ...cells]]
     ];
   },
 });

--- a/packages/extension-templates/src/templates.ts
+++ b/packages/extension-templates/src/templates.ts
@@ -2,7 +2,7 @@
 import { Node } from '@tiptap/core';
 
 const TemplatesNode = Node.create({
-  name: 'templatesnode',
+  name: 'templates',
   group: 'inline',
   inline: true,
   atom: false,

--- a/packages/extension-templates/src/templates.ts
+++ b/packages/extension-templates/src/templates.ts
@@ -41,19 +41,25 @@ const TemplatesNode = Node.create({
   renderHTML({ HTMLAttributes }) {
     const columns = HTMLAttributes.columns || [];
     const titles = columns.map((column) => {
-      if(column.title) {
-        return ["td", {'class': 'title'}, ["h2", {}, column.title]];
+      if (column.title) {
+        return ['td', { class: 'title' }, ['h2', {}, column.title]];
       } else {
-        return ["td", {'class': 'image', rowspan: 2}, ["img", { src: column.image }]];
+        return [
+          'td',
+          { class: 'image', rowspan: 2 },
+          ['img', { src: column.image }],
+        ];
       }
     });
-    const cells = columns.filter(c => !!c.content).map(column => {
-      return ["td", {'class': 'text'}, column.content];
-    });
+    const cells = columns
+      .filter((c) => !!c.content)
+      .map((column) => {
+        return ['td', { class: 'text' }, column.content];
+      });
     return [
-      "table",
-      {'class': 'template'},
-      ["tbody", {}, ["tr", {}, ...titles], ["tr", {}, ...cells]]
+      'table',
+      { class: 'template' },
+      ['tbody', {}, ['tr', {}, ...titles], ['tr', {}, ...cells]],
     ];
   },
 });

--- a/packages/extension-templates/tsconfig.json
+++ b/packages/extension-templates/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "ES2015",
+    "lib": ["es2015", "dom"],
+    "moduleResolution": "node",
+    "declaration": true,
+    "noEmit": true,
+    "rootDir": "./src"
+  },
+  "exclude": ["dist", "build", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,6 +400,33 @@ importers:
         specifier: ^0.34.1
         version: 0.34.1(rollup@3.29.4)(typescript@5.0.2)
 
+  packages/extension-templates:
+    devDependencies:
+      '@rollup/plugin-babel':
+        specifier: ^6.0.3
+        version: 6.0.4(@babel/core@7.23.2)(rollup@3.29.4)
+      '@rollup/plugin-commonjs':
+        specifier: ^24.0.1
+        version: 24.1.0(rollup@3.29.4)
+      '@tiptap/core':
+        specifier: 2.0.3
+        version: 2.0.3(@tiptap/pm@2.0.3)
+      '@tiptap/pm':
+        specifier: 2.0.3
+        version: 2.0.3(@tiptap/core@2.0.3)
+      rollup:
+        specifier: ^3.17.3
+        version: 3.29.4
+      rollup-plugin-auto-external:
+        specifier: ^2.0.0
+        version: 2.0.0(rollup@3.29.4)
+      rollup-plugin-sourcemaps:
+        specifier: ^0.6.3
+        version: 0.6.3(@types/node@20.2.5)(rollup@3.29.4)
+      rollup-plugin-typescript2:
+        specifier: ^0.34.1
+        version: 0.34.1(rollup@3.29.4)(typescript@5.0.2)
+
   packages/extension-typosize:
     devDependencies:
       '@rollup/plugin-babel':


### PR DESCRIPTION
# Description

Dans le cadre de la reprise des données de l'ancien éditeur, on transforme les données générées par des "modèles" (2, 3 colonnes) en tableau.

# Ticket

[WB-2472](https://edifice-community.atlassian.net/browse/WB-2472)

[WB-2472]: https://edifice-community.atlassian.net/browse/WB-2472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ