### PR TITLE
fix: #WB-2452 Workaround selection with table

### DIFF
--- a/packages/extension-table-cell/package.json
+++ b/packages/extension-table-cell/package.json
@@ -31,9 +31,10 @@
   "devDependencies": {
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-commonjs": "^24.0.1",
-    "@tiptap/extension-table-cell": "2.0.3",
     "@tiptap/core": "2.0.3",
+    "@tiptap/extension-table-cell": "2.0.3",
     "@tiptap/pm": "2.0.3",
+    "prosemirror-state": "^1.4.3",
     "rollup": "^3.17.3",
     "rollup-plugin-auto-external": "^2.0.0",
     "rollup-plugin-sourcemaps": "^0.6.3",

--- a/packages/extension-table-cell/src/FixedParagraph.ts
+++ b/packages/extension-table-cell/src/FixedParagraph.ts
@@ -1,0 +1,36 @@
+import { Node, mergeAttributes } from '@tiptap/core';
+
+export const FixedParagraph = Node.create({
+  name: 'fixed-paragraph',
+  key: 'fixed-paragraph',
+
+  addOptions() {
+    return {
+      HTMLAttributes: {
+        class: 'fixed-paragraph',
+      },
+    };
+  },
+
+  group: 'block',
+  isolating: true,
+  selectable: true,
+
+  parseHTML() {
+    return [
+      {
+        tag: 'p[class^=fixed-paragraph]',
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'p',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
+      ' ', // Add a space to the end of the paragraph to make it selectable
+    ];
+  },
+});
+
+export default FixedParagraph;

--- a/packages/extension-table-cell/src/TableCell.ts
+++ b/packages/extension-table-cell/src/TableCell.ts
@@ -1,3 +1,4 @@
+import { mergeAttributes } from '@tiptap/core';
 import { TableCell as TipTapTableCell } from '@tiptap/extension-table-cell';
 
 /**

--- a/packages/extension-table-cell/src/TableCell.ts
+++ b/packages/extension-table-cell/src/TableCell.ts
@@ -1,4 +1,3 @@
-import { mergeAttributes } from '@tiptap/core';
 import { TableCell as TipTapTableCell } from '@tiptap/extension-table-cell';
 
 /**

--- a/packages/extension-table-cell/src/TrailingNode.ts
+++ b/packages/extension-table-cell/src/TrailingNode.ts
@@ -1,0 +1,88 @@
+// TrailingNode extension from:
+// https://gist.github.com/jelleroorda/2a3085f45ef75b9fdd9f76a4444d6bd6/0a2a7b51871bd01808f5663fcab9a4eb3d593559
+// https://tiptap.dev/experiments/trailing-node
+// https://github.com/ueberdosis/tiptap/issues/143
+//
+//   The trailing node extension is necessary to pragmatically fix a problem
+//   with tables and table selections. When the last node in the document is a
+//   table and the last table cell is empty, then pressing <CTRL>-<a> to select
+//   everyting only selects the very first node in the document. As soon as one
+//   of the conditions - table not the last node or last table cell not empty -
+//   is not met, <CTRL>-<a> selects all, as expected.
+//   The Problem exists throughout browsers.
+//
+//   More information here:
+//   - https://github.com/ueberdosis/tiptap/issues/2401
+//   - https://github.com/ueberdosis/tiptap/issues/3651
+//
+
+import { Extension } from '@tiptap/core';
+import { PluginKey, Plugin } from 'prosemirror-state';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function nodeEqualsType({ types, node }: { types: any[]; node: any }) {
+  return (
+    (Array.isArray(types) && types.includes(node.type)) || node.type === types
+  );
+}
+
+/**
+ * Extension based on:
+ * - https://github.com/ueberdosis/tiptap/blob/v1/packages/tiptap-extensions/src/extensions/TrailingNode.js
+ * - https://github.com/remirror/remirror/blob/e0f1bec4a1e8073ce8f5500d62193e52321155b9/packages/prosemirror-trailing-node/src/trailing-node-plugin.ts
+ */
+export const TrailingNode = Extension.create({
+  name: 'trailingNode',
+  key: 'trailingNode',
+
+  defaultOptions: {
+    node: 'fixed-paragraph',
+    notAfter: ['paragraph', 'fixed-paragraph'],
+  },
+
+  addProseMirrorPlugins() {
+    const plugin = new PluginKey(this.name);
+    const disabledNodes = Object.entries(this.editor.schema.nodes)
+      .map(([, value]) => value)
+      .filter((node) => this.options.notAfter.includes(node.name));
+
+    return [
+      new Plugin({
+        key: plugin,
+        appendTransaction: (_, __, state) => {
+          const { doc, tr, schema } = state;
+          const shouldInsertNodeAtEnd = plugin.getState(state);
+          const endPosition = doc.content.size;
+          const type = schema.nodes[this.options.node];
+          if (!shouldInsertNodeAtEnd) {
+            return;
+          }
+
+          return tr.insert(endPosition, type.create(null, [schema.text(' ')]));
+        },
+        state: {
+          init: (_, state) => {
+            const lastNode = state.tr.doc.lastChild;
+            return !nodeEqualsType({
+              node: lastNode,
+              types: disabledNodes,
+            });
+          },
+          apply: (tr, value) => {
+            if (!tr.docChanged) {
+              return value;
+            }
+
+            const lastNode = tr.doc.lastChild;
+            return !nodeEqualsType({
+              node: lastNode,
+              types: disabledNodes,
+            });
+          },
+        },
+      }),
+    ];
+  },
+});
+
+export default TrailingNode;

--- a/packages/extension-table-cell/src/index.ts
+++ b/packages/extension-table-cell/src/index.ts
@@ -1,5 +1,7 @@
 import { TableCell } from './TableCell';
 
-export * from './TableCell';
+export { TableCell } from './TableCell';
+export { FixedParagraph } from './FixedParagraph';
+export { TrailingNode } from './TrailingNode';
 
 export default TableCell;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -514,6 +514,9 @@ importers:
       '@tiptap/pm':
         specifier: 2.0.3
         version: 2.0.3(@tiptap/core@2.0.3)
+      prosemirror-state:
+        specifier: ^1.4.3
+        version: 1.4.3
       rollup:
         specifier: ^3.17.3
         version: 3.29.4
@@ -2052,6 +2055,12 @@ packages:
 
   /@tiptap/extension-text-align@2.0.3(@tiptap/core@2.0.3):
     resolution: {integrity: sha512-VlLgqncKdjMjVjbU60/ALYhFs0wUdjAyvjDXnH1OoM/HuzbILvufPMYz4DUieJIWVJOYUKHQgg4XwBWceAM2Tw==}
+    peerDependencies:
+      '@tiptap/core': ^2.0.0
+    dependencies:
+      '@tiptap/core': 2.0.3(@tiptap/pm@2.0.3)
+    dev: true
+
   /@tiptap/extension-text-style@2.0.3(@tiptap/core@2.0.3):
     resolution: {integrity: sha512-yHIYtZVewSwfBfI6TffnsDRiOuXzytppcCsaDlsZFm8OtLG8v9ioH0ItMoOstmZZBiWJOm8iOy2yWSc4rNQEJw==}
     peerDependencies:


### PR DESCRIPTION
Implement a workaroun for a known issue with Tiptap
https://edifice-community.atlassian.net/browse/WB-2452


//   The trailing node extension is necessary to pragmatically fix a problem
//   with tables and table selections. When the last node in the document is a
//   table and the last table cell is empty, then pressing <CTRL>-<a> to select
//   everyting only selects the very first node in the document. As soon as one
//   of the conditions - table not the last node or last table cell not empty -
//   is not met, <CTRL>-<a> selects all, as expected.
//   The Problem exists throughout browsers.
//
//   More information here:
//   - https://github.com/ueberdosis/tiptap/issues/2401
//   - https://github.com/ueberdosis/tiptap/issues/3651