### PR TITLE
feat: #WB-2501, add new highlight extension to parse and render highlighted text

### DIFF
--- a/packages/extension-highlight/.gitignore
+++ b/packages/extension-highlight/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/packages/extension-highlight/.npmrc
+++ b/packages/extension-highlight/.npmrc
@@ -1,0 +1,1 @@
+auto-install-peers=true

--- a/packages/extension-highlight/README.md
+++ b/packages/extension-highlight/README.md
@@ -1,0 +1,26 @@
+# extension-highlight
+
+![npm](https://img.shields.io/npm/v/@edifice-tiptap-extensions/extension-highlight?style=flat-square)
+![bundlephobia](https://img.shields.io/bundlephobia/min/@edifice-tiptap-extensions/extension-highlight?style=flat-square)
+
+A Tiptap extension to Highlight text
+
+## Installation
+
+With `npm`:
+
+```bash
+npm install @edifice-tiptap-extensions/extension-highlight
+```
+
+With `yarn`:
+
+```bash
+yarn add @edifice-tiptap-extensions/extension-highlight
+```
+
+With `pnpm`:
+
+```bash
+pnpm add @edifice-tiptap-extensions/extension-highlight
+```

--- a/packages/extension-highlight/package.json
+++ b/packages/extension-highlight/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@edifice-tiptap-extensions/extension-highlight",
+  "version": "1.0.0",
+  "description": "Rich Text Editor Highlight Extension",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "version.txt"
+  ],
+  "scripts": {
+    "build": "pnpm run clean && rollup -c",
+    "clean": "rm -rf dist",
+    "dev": "pnpm run clean && rollup -c -w",
+    "format": "pnpm run format:write && pnpm run format:check",
+    "format:check": "prettier --check 'src/**/*.ts'",
+    "format:write": "prettier --write 'src/**/*.ts'",
+    "generate-commit-version": "node ../../scripts/version.cjs",
+    "lint": "eslint src --ext ts --report-unused-disable-directives --max-warnings 0",
+    "fix": "eslint src --fix --ext ts --report-unused-disable-directives --max-warnings 0",
+    "release": "pnpm run generate-commit-version && pnpm run build"
+  },
+  "devDependencies": {
+    "@rollup/plugin-babel": "^6.0.3",
+    "@rollup/plugin-commonjs": "^24.0.1",
+    "@tiptap/extension-highlight": "2.0.3",
+    "@tiptap/core": "2.0.3",
+    "@tiptap/pm": "2.0.3",
+    "rollup": "^3.17.3",
+    "rollup-plugin-auto-external": "^2.0.0",
+    "rollup-plugin-sourcemaps": "^0.6.3",
+    "rollup-plugin-typescript2": "^0.34.1"
+  },
+  "peerDependencies": {
+    "@tiptap/core": "2.0.3",
+    "@tiptap/pm": "2.0.3",
+    "@tiptap/extension-highlight": "2.0.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/extension-highlight/rollup.config.js
+++ b/packages/extension-highlight/rollup.config.js
@@ -1,0 +1,34 @@
+// rollup.config.js
+
+import autoExternal from 'rollup-plugin-auto-external';
+import sourcemaps from 'rollup-plugin-sourcemaps';
+import commonjs from '@rollup/plugin-commonjs';
+import babel from '@rollup/plugin-babel';
+import typescript from 'rollup-plugin-typescript2';
+
+const config = {
+  input: 'src/index.ts',
+  output: [
+    {
+      file: 'dist/index.cjs',
+      format: 'cjs',
+      exports: 'named',
+      sourcemap: true,
+    },
+    {
+      file: 'dist/index.js',
+      format: 'esm',
+      exports: 'named',
+      sourcemap: true,
+    },
+  ],
+  plugins: [
+    autoExternal({ packagePath: './package.json' }),
+    sourcemaps(),
+    babel(),
+    commonjs(),
+    typescript(),
+  ],
+};
+
+export default config;

--- a/packages/extension-highlight/src/highlight.ts
+++ b/packages/extension-highlight/src/highlight.ts
@@ -1,0 +1,19 @@
+import Highlight from '@tiptap/extension-highlight';
+
+export const CustomHighlight = Highlight.extend({
+  name: 'customHighlight',
+
+  parseHTML() {
+    return [
+      {
+        ...this.parent?.(),
+        style: 'background-color',
+        getAttrs: (style) => {
+          return {
+            color: style,
+          };
+        },
+      },
+    ];
+  },
+});

--- a/packages/extension-highlight/src/index.ts
+++ b/packages/extension-highlight/src/index.ts
@@ -1,0 +1,5 @@
+import { CustomHighlight } from './highlight';
+
+export * from './highlight';
+
+export default CustomHighlight;

--- a/packages/extension-highlight/tsconfig.json
+++ b/packages/extension-highlight/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "ES2015",
+    "lib": ["es2015", "dom"],
+    "moduleResolution": "node",
+    "declaration": true,
+    "noEmit": true,
+    "rootDir": "./src"
+  },
+  "exclude": ["dist", "build", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,36 @@ importers:
         specifier: ^0.34.1
         version: 0.34.1(rollup@3.29.4)(typescript@5.3.3)
 
+  packages/extension-highlight:
+    devDependencies:
+      '@rollup/plugin-babel':
+        specifier: ^6.0.3
+        version: 6.0.4(@babel/core@7.23.7)(rollup@3.29.4)
+      '@rollup/plugin-commonjs':
+        specifier: ^24.0.1
+        version: 24.1.0(rollup@3.29.4)
+      '@tiptap/core':
+        specifier: 2.0.3
+        version: 2.0.3(@tiptap/pm@2.0.3)
+      '@tiptap/extension-highlight':
+        specifier: 2.0.3
+        version: 2.0.3(@tiptap/core@2.0.3)
+      '@tiptap/pm':
+        specifier: 2.0.3
+        version: 2.0.3(@tiptap/core@2.0.3)
+      rollup:
+        specifier: ^3.17.3
+        version: 3.29.4
+      rollup-plugin-auto-external:
+        specifier: ^2.0.0
+        version: 2.0.0(rollup@3.29.4)
+      rollup-plugin-sourcemaps:
+        specifier: ^0.6.3
+        version: 0.6.3(@types/node@20.11.5)(rollup@3.29.4)
+      rollup-plugin-typescript2:
+        specifier: ^0.34.1
+        version: 0.34.1(rollup@3.29.4)(typescript@5.3.3)
+
   packages/extension-hyperlink:
     dependencies:
       '@tiptap/extension-link':
@@ -2462,6 +2492,14 @@ packages:
       '@tiptap/core': ^2.0.0
     dependencies:
       '@tiptap/core': 2.0.3(@tiptap/pm@2.0.3)
+
+  /@tiptap/extension-highlight@2.0.3(@tiptap/core@2.0.3):
+    resolution: {integrity: sha512-NrtibY8cZkIjZMQuHRrKd4php+plOvAoSo8g3uVFu275I/Ixt5HqJ53R4voCXs8W8BOBRs2HS2QX8Cjh79XhtA==}
+    peerDependencies:
+      '@tiptap/core': ^2.0.0
+    dependencies:
+      '@tiptap/core': 2.0.3(@tiptap/pm@2.0.3)
+    dev: true
 
   /@tiptap/extension-history@2.1.16(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3):
     resolution: {integrity: sha512-9YHPf8Xqqp5CQy1hJonkBzROj0ZHR1ZaIk9IaLlAPTpdkrUDXV9SC7qp3lozQsMg4vmU3K6H5VQo4ADpnR00OQ==}


### PR DESCRIPTION
# Description

Extension to extend Tiptap's highlight extension.

Parse old content and transform it in `mark` tag, keep existing style on old `span` and return color attribute for `mark` tag.